### PR TITLE
Include MD5 hash for builds

### DIFF
--- a/src/Controller/V1/BuildController.php
+++ b/src/Controller/V1/BuildController.php
@@ -18,10 +18,13 @@ class BuildController extends AbstractController {
             throw $this->createNotFoundException('Could not locate build');
         }
 
+        $hash = $this->getBuildHash($this->getParameterBag(), $project, $version, $build);
+
         $response =  $this->json([
             'project' => $project,
             'version' => $version,
-            'build' => $build
+            'build' => $build,
+            'hash' => $hash
         ]);
         $response->setPublic();
         $response->setSharedMaxAge(604800); # 7 days

--- a/src/V1/BuildCacheTrait.php
+++ b/src/V1/BuildCacheTrait.php
@@ -35,6 +35,20 @@ trait BuildCacheTrait {
         return $builds;
     }
 
+    protected function getBuildHash(ParameterBagInterface $bag, string $project, string $version, string $build) {
+        $cache = $this->getCache($bag);
+        $filePath = $this->getDownloadsPath($bag, $project, $version . '/' . $build . '.jar');
+
+        $cacheKey = static::makeBuildCacheKey($project, $version) . ".$build.hash";
+        $item = $cache->getItem($cacheKey);
+        if (!$item->isHit()) {
+            $item->set(hash_file('md5', $filePath));
+            $cache->save($item);
+        }
+
+        return $item->get();
+    }
+
     protected function findAndCacheBuilds(ParameterBagInterface $bag, CacheItemPoolInterface $cache, string $project, string $version) {
         $builds = $this->findBuilds($bag, $project, $version);
         if(!empty($builds)) {

--- a/src/V1/BuildCacheTrait.php
+++ b/src/V1/BuildCacheTrait.php
@@ -37,11 +37,12 @@ trait BuildCacheTrait {
 
     protected function getBuildHash(ParameterBagInterface $bag, string $project, string $version, string $build) {
         $cache = $this->getCache($bag);
-        $filePath = $this->getDownloadsPath($bag, $project, $version . '/' . $build . '.jar');
 
         $cacheKey = static::makeBuildCacheKey($project, $version) . ".$build.hash";
         $item = $cache->getItem($cacheKey);
+        
         if (!$item->isHit()) {
+            $filePath = $this->getDownloadsPath($bag, $project, $version . '/' . $build . '.jar');
             $item->set(hash_file('md5', $filePath));
             $cache->save($item);
         }


### PR DESCRIPTION
Resolves #5 

My friend kept asking me to +1 issues related to this so I decided to make a pull request so he would stop bugging me. MD5 was used instead of SHA-256 or similar because it's reasonably secure for verifying file integrity, especially when coming from a trusted source.

Also, as an unrelated side note, it doesn't look like it ever actually reads from the cache. For example:

https://github.com/PaperMC/Parchment/blob/3dc9af6f679e2d87b40dc1849c0d8575fb33747d/src/V1/BuildCacheTrait.php#L38-L46

It always writes to the cache, but never reads from it. Is this intended? Is there some Symfony voodoo-magic I'm missing here?